### PR TITLE
do not rely on module for setNewPassword hook

### DIFF
--- a/system/modules/registration_info_mailer/src/Handler.php
+++ b/system/modules/registration_info_mailer/src/Handler.php
@@ -89,10 +89,10 @@ class Handler
      *
      * @return void
      */
-    public function sendChangeMail($objUser, $formData, $objModule)
+    public function sendChangeMail($objUser, $formData, $objModule = null)
     {
         // Check if the registration mail should be send.
-        if ($objModule->rim_change_active == 1) {
+        if (null !== $objModule && $objModule->rim_change_active == 1) {
             $this->getUserOptions($objUser);
 
             // Check if we have all needed data.


### PR DESCRIPTION
The `setNewPassword` hook is also executed in the DCA of `tl_member`. However, there the third parameter (the module) will be missing of course - thus you cannot rely on the module being present for that hook. Otherwise the following error will occur:
```
[18-Oct-2018 14:35:37 Europe/Vienna] PHP Fatal error: Uncaught exception 'ArgumentCountError' with message 'Too few arguments to function RegistrationInfoMailer\Handler::sendChangeMail(), 2 passed in system\modules\core\dca\tl_member.php on line 606 and exactly 3 expected' thrown in composer\vendor\menatwork\registration_info_mailer\system\modules\registration_info_mailer\src\Handler.php on line 92
#0 system\modules\core\dca\tl_member.php(606): RegistrationInfoMailer\Handler->sendChangeMail(Object(Contao\Database\Mysqli\Result), '…')
#1 system\modules\core\drivers\DC_Table.php(2972): tl_member->setNewPassword('…', Object(Contao\DC_Table))
#2 system\modules\core\classes\DataContainer.php(353): Contao\DC_Table->save('…')
#3 system\modules\core\drivers\DC_Table.php(1943): Contao\DataContainer->row('{personal_legen...')
#4 system\modules\core\classes\Backend.php(650): Contao\DC_Table->edit()
#5 system\modules\core\controllers\BackendMain.php(131): Contao\Backend->getBackendModule('member')
#6 contao\main.php(20): Contao\BackendMain->run()
#7 {main}
```