### PR TITLE
Always replace rim insert tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"source":"https://github.com/menatwork-ia/registration_info_mailer"
 	},
 	"require":{
-		"php":">=5.3",
+		"php":">=7.0",
 		"contao/core-bundle":"^3.2 || ^4.4",
 		"contao-community-alliance/composer-plugin":"^2.4 || ^3.0",
 		"terminal42/notification_center":"^1.0"

--- a/system/modules/registration_info_mailer/src/Handler.php
+++ b/system/modules/registration_info_mailer/src/Handler.php
@@ -183,18 +183,17 @@ class Handler
      */
     public function replaceRimInsertTags($strTag)
     {
-        if (count(self::$arrUserOptions) === 0) {
+        $arrTemp = explode('::', $strTag);
+
+        if ('rim' !== $arrTemp[0]) {
             return false;
         }
 
-        $arrTemp = explode('::', $strTag);
-
-        // check if it's our rim insert tag
-        if ($arrTemp[0] == 'rim' && isset(self::$arrUserOptions[$arrTemp[1]])) {
-            return self::$arrUserOptions[$arrTemp[1]];
+        if (empty($arrTemp[1])) {
+            return '';
         }
 
-        return false;
+        return self::$arrUserOptions[$arrTemp[1]] ?? '';
     }
 
     /**


### PR DESCRIPTION
Currently there can be a lot of

```
Unknown insert tag {{rim::xyz}} on page …
```

system log entries when using the `{{rim::*}}` insert tag, because the hook implementation returns false in case no data has been set or the provided attribute does not exist. However, insert tags must _always_ be replaced (to avoid this message). This PR fixes that by always replacing the insert tag (with an empty string otherwise not applicable).